### PR TITLE
Change bundle category of Tauri

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
     },
     "bundle": {
       "active": true,
-      "category": "DeveloperTool",
+      "category": "Utility",
       "copyright": "",
       "deb": {
         "depends": []


### PR DESCRIPTION
I think the Wireguard GUI is definitely **NOT** a programming tool. So maybe a utility tool? Select a better string from: https://tauri.app/v1/api/config/#bundleconfig.category. For now I picked Utility. 