### PR TITLE
Added flake.nix to this repo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1737700483,
+        "narHash": "sha256-1778bR4GDDc51/iZQvcshGLZ4JU87zCzqei8Hn7vU1A=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bab2a2840bc2d5ae7c6a133602185edbe4ca7daa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737634189,
+        "narHash": "sha256-AG5G9KDsl0Ngby9EfWvlemma7WWG0KCADTIccPJuzUE=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "84d44d0a574630aa8500ed62b6c01ccd3fae2473",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  # main
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  # dev
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ] (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = with inputs; [
+            fenix.overlays.default
+          ];
+        };
+        wireguard-gui-tauri = pkgs.callPackage ./nix/wireguard-gui.nix { };
+      in
+      {
+        packages.default = wireguard-gui-tauri;
+      }
+    );
+}

--- a/nix/wireguard-gui.nix
+++ b/nix/wireguard-gui.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchNpmDeps,
+  cargo-tauri_1,
+  darwin,
+  glib-networking,
+  libsoup,
+  nodejs_22,
+  npmHooks,
+  libiconv,
+  openssl,
+  pkg-config,
+  webkitgtk,
+  wrapGAppsHook3,
+  makeBinaryWrapper,
+}:
+
+let
+  src = ../.;
+  toml = (lib.importTOML ../src-tauri/Cargo.toml).package;
+in
+rustPlatform.buildRustPackage rec {
+  pname = toml.name;
+  inherit src;
+  inherit (toml) version;
+
+  npmDeps = fetchNpmDeps {
+    inherit pname version src;
+    hash = "sha256-5nteidw81/EUc3TJT3WFC+m3pN/ZuUeepYKdvn/VwzA=";
+  };
+
+  cargoRoot = "src-tauri";
+  useFetchCargoVendor = true;
+
+  cargoLock.lockFile = "${src}/src-tauri/Cargo.lock";
+
+  buildAndTestSubdir = cargoRoot;
+
+  nativeBuildInputs =
+    [
+      nodejs_22
+      npmHooks.npmConfigHook
+      cargo-tauri_1.hook
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook3 ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeBinaryWrapper ];
+
+  buildInputs =
+    [
+      openssl
+      libiconv
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      glib-networking # Most Tauri apps need networking
+      libsoup
+      webkitgtk
+    ]
+    ++ lib.optionals stdenv.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AppKit
+        CoreServices
+        Security
+        WebKit
+      ]
+    );
+
+  doCheck = false;
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeWrapper $out/Applications/wireguard-gui.app/Contents/MacOS/wireguard-gui $out/bin/wireguard-gui
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    # NODE_ENV = "production";
+  };
+}


### PR DESCRIPTION
I can get the build using `nix build`. 

However upon running I get the following issue though, running on M1 Mac. It appears like I can't get a normal build too when going through readme unfortunately.

```shell
2025-01-24 18:36:21.047 wireguard-gui[54734:54172830] +[IMKClient subclass]: chose IMKClient_Modern
2025-01-24 18:36:21.047 wireguard-gui[54734:54172830] +[IMKInputSession subclass]: chose IMKInputSession_Modern
RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayLink(): page has no displayID
```

![image](https://github.com/user-attachments/assets/10b66fb5-bb4d-477e-9333-42c9837da32f)
