### PR TITLE
fix: avoid restoring broken window geometry on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - unreleased
+
+### Fixed
+
+- KDE Plasma / KWin window sizing and override issues caused by restoring stale window geometry
+
 ## [0.1.9] - 2026-05-30
 
 ### Added

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 const isProd = process.env.NODE_ENV === 'production';
 
 const internalHost = process.env.TAURI_DEV_HOST || 'localhost';
+const devPort = process.env.PORT || '3000';
+const devOrigin =
+  process.env.NEXT_DEV_ORIGIN || `http://${internalHost}:${devPort}`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -14,7 +17,7 @@ const nextConfig = {
     unoptimized: true,
   },
   // Configure assetPrefix or else the server won't properly resolve your assets.
-  assetPrefix: isProd ? undefined : `http://${internalHost}:3000`,
+  assetPrefix: isProd ? undefined : devOrigin,
 };
 
 export default nextConfig;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,12 @@ const TRAY_CONNECTED_ICON: &[u8] =
   include_bytes!("../icons/tray_connected.png");
 const TRAY_DISCONNECTED_ICON: &[u8] = include_bytes!("../icons/tray.png");
 
+fn window_state_flags() -> StateFlags {
+  // The main window is fixed-size; restoring geometry beyond position can
+  // fight Linux compositors and replay stale monitor-scale state.
+  StateFlags::POSITION
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IpPayload {
   pub origin: String,
@@ -794,12 +800,12 @@ fn build_tray(conn_st: &ConnSt, app: &App) -> Result<TrayIcon, Box<dyn std::erro
         match event.id.as_ref() {
           "quit" => {
             // will save the state of all open windows to disk
-            let _ = app.save_window_state(StateFlags::all());
+            let _ = app.save_window_state(window_state_flags());
             app.exit(0);
           }
           "open" => {
             if let Some(window) = app.get_webview_window("main") {
-              let _ = window.restore_state(StateFlags::all());
+              let _ = window.restore_state(window_state_flags());
               let _ = window.show();
               let _ = window.set_focus();
             }
@@ -876,10 +882,15 @@ async fn main() {
   })
     .manage(managed_app_state)
     .plugin(tauri_plugin_dialog::init())
-    .plugin(tauri_plugin_window_state::Builder::default().build())
+    .plugin(
+      tauri_plugin_window_state::Builder::default()
+        .with_state_flags(window_state_flags())
+        .skip_initial_state("main")
+        .build(),
+    )
     .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
       if let Some(window) = app.get_webview_window("main") {
-        let _ = window.restore_state(StateFlags::all());
+        let _ = window.restore_state(window_state_flags());
         let _ = window.show();
         let _ = window.set_focus();
       }


### PR DESCRIPTION
## Summary

Fix a Linux/KWin window regression introduced by restoring the full Tauri window state for a fixed-size window.

## What changed

- save and restore window position only, instead of restoring the full window geometry/state
- skip the initial window-state restore for the main window so compositor and window-manager rules can apply normally on startup
- keep tray reopen and single-instance activation restoring the saved position
- make the Next.js dev asset origin configurable so alternate local dev ports work correctly without changing the default upstream `localhost:3000` behavior

## Root cause

The recent window-state change started restoring `StateFlags::all()`. On Linux, that can replay stale size, maximized, or fullscreen geometry for a fixed-size window, which breaks KWin sizing and window override behavior.

## Validation

- reproduced the bad behavior with the current window-state implementation
- verified the patched build no longer breaks KWin sizing or overrides
- confirmed the dev-origin change still defaults to `localhost:3000` unless an alternate port is explicitly provided
- ran `git diff --check`

Fixes #441