### PR TITLE
fix: force LC_ALL=C in wg.sh to fix parsing on non-English locales

### DIFF
--- a/src-tauri/scripts/wg.sh
+++ b/src-tauri/scripts/wg.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+export LC_ALL=C
 
 home="${HOME:-}"
 profile="${PROFILE:-}"


### PR DESCRIPTION
Closes #444

Added `export LC_ALL=C` to wg.sh so nmcli always outputs English text,
allowing the script to correctly parse the connection name regardless of system locale

Tested on Ubuntu with Russian locale — VPN connects successfully after the fix.

Note: This fix was identified with the help of Claude AI. 
I'm not deeply familiar with the codebase, so feel free to suggest a better approach if needed